### PR TITLE
Add spark-hyperloglog to Mozilla

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,14 +1,14 @@
 name := "spark-hyperloglog"
 
-version := "1.1.1"
+version := "2.0.0"
 
 scalaVersion := "2.11.8"
 
-spName := "vitillo/spark-hyperloglog"
+spName := "mozilla/spark-hyperloglog"
 
 spIncludeMaven := false
 
-sparkVersion := "2.0.0"
+sparkVersion := "2.0.2"
 
 sparkComponents ++= Seq("core", "sql")
 

--- a/src/main/scala/com/mozilla/spark/sql/hyperloglog/functions/package.scala
+++ b/src/main/scala/com/mozilla/spark/sql/hyperloglog/functions/package.scala
@@ -25,7 +25,7 @@ package object functions {
   def hllCreate(x: String, bits: Int): Array[Byte] = {
     x match {
       case null => null
-      case v: String =>
+      case _ =>
         val monoid = new HyperLogLogMonoid(bits)
         HyperLogLog.toBytes(monoid.toHLL(x))
     }

--- a/src/main/scala/com/mozilla/spark/sql/hyperloglog/functions/package.scala
+++ b/src/main/scala/com/mozilla/spark/sql/hyperloglog/functions/package.scala
@@ -23,7 +23,11 @@ package object functions {
   // See algebird-core/src/main/scala/com/twitter/algebird/HyperLogLog.scala#L194-L210
   // E.g. 12 bits corresponds to an error of 0.0163
   def hllCreate(x: String, bits: Int): Array[Byte] = {
-    val monoid = new HyperLogLogMonoid(bits)
-    HyperLogLog.toBytes(monoid.toHLL(x))
+    x match {
+      case null => null
+      case v: String =>
+        val monoid = new HyperLogLogMonoid(bits)
+        HyperLogLog.toBytes(monoid.toHLL(x))
+    }
   }
 }

--- a/src/test/scala/com/mozilla/spark/sql/hyperloglog/test/HyperLogLog.scala
+++ b/src/test/scala/com/mozilla/spark/sql/hyperloglog/test/HyperLogLog.scala
@@ -15,31 +15,66 @@ package com.mozilla.spark.sql.hyperloglog.test
 
 import com.mozilla.spark.sql.hyperloglog.aggregates._
 import com.mozilla.spark.sql.hyperloglog.functions._
-import org.apache.spark.sql.SQLContext
-import org.apache.spark.sql.functions._
-import org.apache.spark.{SparkConf, SparkContext}
-import org.scalatest.{FlatSpec, Matchers}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions.expr
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 
-class HyperLogLogTest extends FlatSpec with Matchers{
- "Algebird's HyperLogLog" can "be used from Spark" in {
-  val sparkConf = new SparkConf().setAppName("HyperLogLog")
-  sparkConf.setMaster(sparkConf.get("spark.master", "local[1]"))
+case class ClientRow(id: String, os: String)
 
-  val sc = new SparkContext(sparkConf)
-  val sqlContext = new SQLContext(sc)
-  import sqlContext.implicits._
+class HyperLogLogTest extends FlatSpec with Matchers with BeforeAndAfterAll {
 
-  val hllMerge = new HyperLogLogMerge
-  sqlContext.udf.register("hll_merge", hllMerge)
-  sqlContext.udf.register("hll_create", hllCreate _)
-  sqlContext.udf.register("hll_cardinality", hllCardinality _)
+  val spark = SparkSession.builder()
+      .master("local[*]")
+      .appName("Spark HyperLogLog Test")
+      .getOrCreate()
 
-  val frame = sc.parallelize(List("a", "b", "c", "c"), 4).toDF("id")
-  val count = frame
-    .select(expr("hll_create(id, 12) as hll"))
-    .groupBy()
-    .agg(expr("hll_cardinality(hll_merge(hll)) as count"))
-    .collect()
-  count(0)(0) should be (3)
- }
+  val osList = "windows" :: "macos" :: "linux" :: Nil
+  val predata = List(
+    ClientRow("a", "windows"),
+    ClientRow("b", "windows"),
+    ClientRow("c", "macos"),
+    ClientRow("c", "macos"),
+    ClientRow(null, "linux")
+  )
+
+  "Algebird's HyperLogLog" can "be used from Spark" in {
+    import spark.implicits._
+
+    val hllMerge = new HyperLogLogMerge
+    spark.udf.register("hll_merge", hllMerge)
+    spark.udf.register("hll_create", hllCreate _)
+    spark.udf.register("hll_cardinality", hllCardinality _)
+
+    val rows = predata.toDS().toDF()
+      .selectExpr("hll_create(id, 12) as hll")
+      .groupBy()
+      .agg(expr("hll_cardinality(hll_merge(hll)) as count"))
+      .collect()
+    rows(0)(0) should be (3)
+  }
+
+  "HyperLogLog" can "handle null and missing values" in {
+    import spark.implicits._
+
+    val hllMerge = new HyperLogLogMerge
+    spark.udf.register("hll_merge", hllMerge)
+    spark.udf.register("hll_create", hllCreate _)
+    spark.udf.register("hll_cardinality", hllCardinality _)
+
+    val rows = predata.toDS()
+      .selectExpr("os", "hll_create(id, 12) as hll")
+      .groupBy()
+      .pivot("os", osList)
+      .agg(expr("hll_cardinality(hll_merge(hll)) as count"))
+      .collect()
+
+    rows.length should be (1)
+    rows(0).getAs[Integer]("windows") should be (2)
+    rows(0).getAs[Integer]("macos") should be (1)
+    rows(0).getAs[Integer]("linux") should be (0)
+  }
+
+  override def afterAll = {
+    spark.stop()
+  }
 }


### PR DESCRIPTION
This also adds the changes I made for Quantum RC, as well as updates some tests. I bumped the version to 2.0.0 since the API has changed. We can release this on spark-packages under the mozilla name and it will be separate from vitillo/spark-hyperloglog.