### PR TITLE
[Bug 1375018] Spark hyperloglog add maven local repo to replace sonatype

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@ Algebird's HyperLogLog support for Apache Spark. This package can be used in con
 with [presto-hyperloglog](https://github.com/vitillo/presto-hyperloglog) to share
 HyperLogLog sets between Spark and Presto.
 
-[![Build Status](https://travis-ci.org/vitillo/spark-hyperloglog.svg?branch=master)](https://travis-ci.org/vitillo/spark-hyperloglog) [![codecov.io](https://codecov.io/github/vitillo/spark-hyperloglog/coverage.svg?branch=master)](https://codecov.io/github/vitillo/spark-hyperloglog?branch=master)
+[![Build Status](https://travis-ci.org/vitillo/spark-hyperloglog.svg?branch=master)](https://travis-ci.org/vitillo/spark-hyperloglog)
+[![codecov.io](https://codecov.io/github/vitillo/spark-hyperloglog/coverage.svg?branch=master)](https://codecov.io/github/vitillo/spark-hyperloglog?branch=master)
+[![CircleCi](https://circleci.com/gh/mozilla/spark-hyperloglog.png?circle-token=5506f56072f0198ece2995a8539c174cc648c9e4)](https://circleci.com/gh/mozilla/spark-hyperloglog.svg?style=shield&circle-token=5506f56072f0198ece2995a8539c174cc648c9e4)
+
 
 ### Example usage
 ```scala
@@ -34,12 +37,5 @@ yields:
 ```
 
 ### Deployment
-1. Configure your credentials for the Spark Packages repository in `~/.ivy2/.sbtcredentials`, e.g:
-   ```
-   realm=Sonatype Nexus Repository Manager
-   host=oss.sonatype.org
-   user=foo
-   password=bar
-   ```
-
-2. Publish a new release with `sbt publishSigned`
+Any commits to master should also trigger a circleci build that will do the sbt publishing for you
+to our local maven repo in s3.

--- a/build.sbt
+++ b/build.sbt
@@ -20,11 +20,11 @@ credentials += Credentials(Path.userHome / ".ivy2" / ".sbtcredentials")
 publishMavenStyle := true
 
 publishTo := {
-  val nexus = "https://oss.sonatype.org/"
+  val localMaven = "s3://net-mozaws-data-us-west-2-ops-mavenrepo/"
   if (isSnapshot.value)
-    Some("snapshots" at nexus + "content/repositories/snapshots")
+    Some("snapshots" at localMaven + "snapshots")
   else
-    Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+    Some("releases"  at localMaven + "releases")
 }
 
 licenses += "Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0")

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,15 @@
+machine:
+  pre:
+    # Install sbt 0.13.16
+    - sudo apt-get install openjdk-8-jdk
+    - wget -q https://dl.bintray.com/sbt/debian/sbt-0.13.16.deb
+    - sudo dpkg -i sbt-0.13.16.deb
+  cache_directories:
+    - "~/.ivy2"
+    - "~/.sbt"
+
+deployment:
+  latest:
+    branch: master
+    commands:
+      - sbt publish

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,4 +6,4 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.1.0")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+addSbtPlugin("com.frugalmechanic" % "fm-sbt-s3-resolver" % "0.12.0")


### PR DESCRIPTION
- Spark hyperloglog add maven local repo to replace sonatype
- Add circleci build to automatically publish jar to local maven repo on commits to master (this will require extra setup on the github side)