### PR TITLE
Add filters to CircleCI test job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,10 @@ workflows:
   version: 2
   test-publish:
     jobs:
-      - test
+      - test:
+          filters:
+            tags:
+              only: /^.*/  # Runs for all branches and tags
       # Publish only runs on builds triggered by a new git tag of form vX.X.X
       - publish:
           requires:


### PR DESCRIPTION
Per https://circleci.com/docs/2.0/workflows/#git-tag-job-execution

> a job must have a filters tags section to run as a part of a tag push