### PR TITLE
Update pyspark usage instructions to avoid warning

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -15,7 +15,7 @@ The package will register itself with the current pyspark installation
 location in the current site-packages. This allows for tests against spark in standalone mode.
 
 ```python
-from pyspark.sql import SparkSession
+from pyspark.sql import SparkSession, Row
 from pyspark.sql.functions import expr
 
 from pyspark_hyperloglog import hll
@@ -23,7 +23,7 @@ from pyspark_hyperloglog import hll
 
 spark = SparkSession.builder.getOrCreate()
 
-frame = spark.createDataFrame([{'id': x} for x in ['a', 'b', 'c', 'c']])
+frame = spark.createDataFrame([Row(id=x) for x in ['a', 'b', 'c', 'c']])
 hll.register()
 
 (
@@ -34,6 +34,11 @@ hll.register()
     .show()
 )
 
+# +-----+
+# |count|
+# +-----+
+# |    3|
+# +-----+
 ```
 
 If you run into issues during `.register()`, make sure that the dataframe has been created before registering the


### PR DESCRIPTION
Avoids `UserWarning: inferring schema from dict is deprecated, please use pyspark.sql.Row instead`