### PR TITLE
Update example usage for modern Spark versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,21 +16,22 @@ on spark-packages.org, so is available via:
 
 
 ### Example usage
+
 ```scala
 import com.mozilla.spark.sql.hyperloglog.aggregates._
 import com.mozilla.spark.sql.hyperloglog.functions._
 
 val hllMerge = new HyperLogLogMerge
-sqlContext.udf.register("hll_merge", hllMerge)
-sqlContext.udf.register("hll_create", hllCreate _)
-sqlContext.udf.register("hll_cardinality", hllCardinality _)
+spark.udf.register("hll_merge", hllMerge)
+spark.udf.register("hll_create", hllCreate _)
+spark.udf.register("hll_cardinality", hllCardinality _)
 
 val frame = sc.parallelize(List("a", "b", "c", "c")).toDF("id")
-val count = frame
+(frame
   .select(expr("hll_create(id, 12) as hll"))
   .groupBy()
   .agg(expr("hll_cardinality(hll_merge(hll)) as count"))
-  .show()
+  .show())
 ```
 
 yields:


### PR DESCRIPTION
sqlContext is deprecated